### PR TITLE
Add multi view support for parameterized routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,16 @@ To use transition, you need to use the `viewName` prop to set the name of the vi
 ```
 
 Here `view-name` and `morph` are `<router-multi-view/>` props, while `tag` and `name` are `<transition-group>` props.
+
+To render multi views for parameterized route (such as /a/b/:aParam), 
+you can use the `forceMultiViews` option globally :
+```javascript
+Vue.use(VueRouterMultiView, { forceMultiViews: true });
+```
+
+or locally :
+```html
+<router-multi-view
+  :force-multi-views="true"
+/>
+```

--- a/src/components/multi-view.js
+++ b/src/components/multi-view.js
@@ -80,7 +80,10 @@ export default {
     const matched = route.matched[depth]
     if (matched) {
       // Get effective route (with instantiated url params) as key
-      const key = getEffectiveRoute(matched.path, route)
+      let key = matched.path
+      if (props.forceMultiViews) {
+        key = getEffectiveRoute(matched.path, route)
+      }
       const cache = bigCache[key] || (bigCache[key] = {})
 
       // render previous view if the tree is inactive and kept-alive

--- a/src/components/multi-view.js
+++ b/src/components/multi-view.js
@@ -17,6 +17,7 @@ function updateActive (isCurrent, cached, vm) {
 
 function getEffectiveRoute(key, currentRoute) {
   let effectiveRoute = key;
+  // Fetch url params names
   const tokensRegex = /.*:([a-zA-Z0-9]+)\/?.*/g;
   const matchedTokens = tokensRegex.exec(key);
   const queryParamsName =
@@ -74,6 +75,7 @@ export default {
 
     const matched = route.matched[depth]
     if (matched) {
+      // Get effective route (with instantiated url params) as key
       const key = getEffectiveRoute(matched.path, route)
       const cache = bigCache[key] || (bigCache[key] = {})
 

--- a/src/components/multi-view.js
+++ b/src/components/multi-view.js
@@ -47,6 +47,10 @@ export default {
       type: [String, Object, Function],
       default: 'div',
     },
+    forceMultiViews: {
+      type: Boolean,
+      default: false,
+    },
   },
   render (_, { props, parent, data, children }) {
     // directly use parent context's createElement() function

--- a/src/components/multi-view.js
+++ b/src/components/multi-view.js
@@ -15,6 +15,25 @@ function updateActive (isCurrent, cached, vm) {
   }
 }
 
+function getEffectiveRoute(key, currentRoute) {
+  let effectiveRoute = key;
+  const tokensRegex = /.*:([a-zA-Z0-9]+)\/?.*/g;
+  const matchedTokens = tokensRegex.exec(key);
+  const queryParamsName =
+    matchedTokens && matchedTokens.length && matchedTokens.length > 1
+      ? matchedTokens.slice(1)
+      : [];
+  queryParamsName.forEach(paramName => {
+    if (currentRoute.params && currentRoute.params[paramName]) {
+      effectiveRoute = effectiveRoute.replace(
+        new RegExp(`:${paramName}`, "g"),
+        currentRoute.params[paramName]
+      );
+    }
+  });
+  return effectiveRoute;
+}
+
 export default {
   name: 'RouterView',
   functional: true,
@@ -55,7 +74,7 @@ export default {
 
     const matched = route.matched[depth]
     if (matched) {
-      const key = matched.path
+      const key = getEffectiveRoute(matched.path, route)
       const cache = bigCache[key] || (bigCache[key] = {})
 
       // render previous view if the tree is inactive and kept-alive

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,13 @@ import MultiView from './components/multi-view'
 
 export let Vue
 
-export function install (pVue) {
+export function install (pVue, options = { forceMultiViews: false }) {
   if (install.installed) return
   install.installed = true
 
   Vue = pVue
+
+  MultiView.props.forceMultiViews.default = options.forceMultiViews;
 
   Vue.component('router-multi-view', MultiView)
 }


### PR DESCRIPTION
With this fix, parameterized routes render multi views, i.e for the route pattern : `/my/route/:aParam`, `/my/route/PARAM1` and `/my/route/PARAM2` will render two views in DOM

Naïve fix to resolve #4 