### PR TITLE
Add props 'alt-key' for a alternavive key

### DIFF
--- a/demo-src/src/main.js
+++ b/demo-src/src/main.js
@@ -3,6 +3,8 @@ import { router } from './router'
 import VueRouterMultiView from '../../'
 import App from './App.vue'
 
+Vue.config.devtools = true;
+
 Vue.use(VueRouterMultiView)
 
 // eslint-disable-next-line no-new

--- a/demo-src/src/main.js
+++ b/demo-src/src/main.js
@@ -3,8 +3,6 @@ import { router } from './router'
 import VueRouterMultiView from '../../'
 import App from './App.vue'
 
-Vue.config.devtools = true;
-
 Vue.use(VueRouterMultiView)
 
 // eslint-disable-next-line no-new

--- a/src/components/multi-view.js
+++ b/src/components/multi-view.js
@@ -19,6 +19,10 @@ export default {
   name: 'RouterView',
   functional: true,
   props: {
+    altKey: {
+      type: String,
+      default: null,
+    },
     viewName: {
       type: String,
       default: 'default',
@@ -55,7 +59,7 @@ export default {
 
     const matched = route.matched[depth]
     if (matched) {
-      const key = matched.path
+      const key = props.altKey || matched.path
       const cache = bigCache[key] || (bigCache[key] = {})
 
       // render previous view if the tree is inactive and kept-alive


### PR DESCRIPTION
Added: alt-key property

As mentioned on #9 

A major problem of setting key as parent's path is that can't handle default url like *.

``` javascript
export const routes = [
  { path: '/', name: 'page-a', component: PageA, meta: { exact: true } },
  { path: '/b/:id', name: 'page-b', component: PageB },
  {
    path: '*',
    component: DefaultComponent,
  },
]
```

on above code, multi-router-view make only one instance when a router push both '/c' and '/d'.
but sometimes two different path '/c' and '/d' want two different instances.

Therefore, multi-router-view should have alternative way to set a cache key to handle various business logic.

Usage:

``` html
<router-multi-view
      class="wrapper"
      morph="transition-group"
      tag="div"
      name="fade"
      view-name="default"

      :alt-key="$route.path"
    />
```